### PR TITLE
CopywritingPhrase::Translation accessbile attribute: locale

### DIFF
--- a/app/models/copywriting_phrase.rb
+++ b/app/models/copywriting_phrase.rb
@@ -6,6 +6,12 @@ class CopywritingPhrase < ActiveRecord::Base
 
   attr_accessible :locale, :name, :default, :value, :scope, :page_id, :phrase_type
 
+  if defined?(::CopywritingPhrase::Translation)
+    ::CopywritingPhrase::Translation.module_eval do
+      attr_accessible :locale
+    end
+  end
+  
   def self.for(name, options = {})
     options = {:phrase_type => 'text', :scope => 'default'}.merge(options)
     name = name.to_s


### PR DESCRIPTION
The following is an error I encountered when trying out refinerycms-copywriting.

```
    13:21:07 active_record CopywritingPhrase Load (0.5ms)  SELECT "copywriting_phrases".* FROM "copywriting_phrases" WHERE "copywriting_phrases"."name" = 'foo' AND "copywriting_phrases"."page_id" IS NULL LIMIT 1
    13:21:07 active_record SQL (0.1ms)  BEGIN
    13:21:07 active_record SQL (0.7ms)  INSERT INTO "copywriting_phrases" ("name", "default", "value", "scope", "page_id", "created_at", "updated_at", "phrase_type") VALUES ('foo', 'bar', NULL, 'default', NULL, '2011-09-19 17:21:07.780691', '2011-09-19 17:21:07.780691', 'text') RE
    13:21:07 active_record CopywritingPhrase::Translation Load (0.4ms)  SELECT "copywriting_phrase_translations".* FROM "copywriting_phrase_translations" WHERE "copywriting_phrase_translations"."locale" = 'en' AND ("copywriting_phrase_translations".copywriting_phrase_id = 1) LIMIT
    13:21:07 WARNING: Can't mass-assign protected attributes: locale
    13:21:07 active_record SQL (0.7ms)  INSERT INTO "copywriting_phrase_translations" ("copywriting_phrase_id", "locale", "value", "created_at", "updated_at") VALUES (1, NULL, NULL, '2011-09-19 17:21:07.796851', '2011-09-19 17:21:07.796851') RETURNING "id"
    13:21:07 active_record CopywritingPhrase::Translation Load (0.2ms)  SELECT "copywriting_phrase_translations".* FROM "copywriting_phrase_translations" WHERE ("copywriting_phrase_translations".copywriting_phrase_id = 1)
    13:21:07 active_record SQL (0.1ms)  ROLLBACK


```

This patch makes the locale attribute on the CopywritingPhrase::Translation object accessible if it is defined. This is similar to how the Page and PagePart models are defined.
