### PR TITLE
Update app/views/admin/pages/tabs/_copywriting.html.erb

### DIFF
--- a/app/views/admin/pages/tabs/_copywriting.html.erb
+++ b/app/views/admin/pages/tabs/_copywriting.html.erb
@@ -1,4 +1,4 @@
-<% copywriting_phrases = @page.copywriting_phrases %>
+<% copywriting_phrases = @page.copywriting_phrases.order([:scope, :name]) %>
 <% if copywriting_phrases and copywriting_phrases.any? %>
   <div class='wym_skin_refinery page_part' id='copywritting-tab'>
     <ul>


### PR DESCRIPTION
Changed

``` ruby
<% copywriting_phrases = @page.copywriting_phrases %>
```

to

``` ruby
<% copywriting_phrases = @page.copywriting_phrases.order([:scope, :name]) %>
```

So it orders the phrases correctly after the scope and then the name!

This is an awesome plugin! :-)

Cheers!
