### PR TITLE
Fixed translation paths for namespacing.

### DIFF
--- a/app/views/refinery/copywriting/admin/phrases/_phrase.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_phrase.html.erb
@@ -13,7 +13,7 @@
     <%= link_to refinery_icon_tag("delete.png"), refinery.copywriting_admin_phrase_path(phrase),
          :title => t('.delete'),
          :class => "cancel confirm-delete",
-         :confirm => t('message', :scope => 'shared.admin.delete', :title => phrase.name.capitalize),
+         :confirm => t('message', :scope => 'refinery.admin.delete', :title => phrase.name.capitalize),
          :method => :delete %>
 
   </span>

--- a/app/views/refinery/copywriting/admin/phrases/_records.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_records.html.erb
@@ -8,7 +8,7 @@
           <%= t('.no_items_yet') %>
         </strong>
       <% else %>
-        <%= t('no_results', :scope => 'shared.admin.search') %>
+        <%= t('no_results', :scope => 'refinery.admin.search') %>
       <% end %>
     </p>
   <% end %>


### PR DESCRIPTION
A couple of the translation paths hadn't been updated for the namespacing changes in Refinery.
