### PR TITLE
Do not make apps depend on rspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,7 @@ require "refinerycms-testing"
 Refinery::Testing::Railtie.load_tasks
 Refinery::Testing::Railtie.load_dummy_tasks(ENGINE_PATH)
 
-load File.expand_path('../lib/tasks/rspec.rake', __FILE__)
+require 'rspec/core/rake_task'
+
+desc "Run specs"
+RSpec::Core::RakeTask.new

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,4 +1,0 @@
-require 'rspec/core/rake_task'
-
-desc "Run specs"
-RSpec::Core::RakeTask.new


### PR DESCRIPTION
After upgrading to 2.0.1 my rake tasks stopped working:

```
$ rake -T --trace

cannot load such file -- rspec/core/rake_task
.../gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
.../gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `block in require'
.../gems/activesupport-3.2.2/lib/active_support/dependencies.rb:236:in `load_dependency'
.../gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
.../gems/refinerycms-copywriting-2.0.1/lib/tasks/rspec.rake:1:in `<top (required)>'
```

I moved the `rspec.rake` to `Rakefile` to avoid this.
