### PR TITLE
Inherit from Refinery::Core::BaseModel instead of ActiveRecord::Base directly.

### DIFF
--- a/app/models/refinery/copywriting/phrase.rb
+++ b/app/models/refinery/copywriting/phrase.rb
@@ -1,6 +1,6 @@
 module Refinery
   module Copywriting
-    class Phrase < ActiveRecord::Base
+    class Phrase < Refinery::Core::BaseModel
 
       belongs_to :page, :class_name => 'Refinery::Page'
       translates :value if self.respond_to?(:translates)


### PR DESCRIPTION
See [this](https://github.com/resolve/refinerycms/commit/d793846850144554b8430458e913e0bf3d824b28) commit message.
