### PR TITLE
Remove sorting vestiges.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,7 @@ Refinery::Core::Engine.routes.draw do
   namespace :copywriting, :path => '' do
     namespace :admin, :path => 'refinery' do
       scope :path => 'copywriting' do
-        resources :phrases, :except => [:show, :new, :create] do
-          collection do
-            post :update_positions
-          end
-        end
+        resources :phrases, :except => [:show, :new, :create]
       end
     end
   end


### PR DESCRIPTION
Since copywriting strings are not sortable, there's no sense in having an 'update positions' route -- it just clutters up the routing table.
