### PR TITLE
Respect scope as record differentiator.

### DIFF
--- a/app/models/refinery/copywriting/phrase.rb
+++ b/app/models/refinery/copywriting/phrase.rb
@@ -19,7 +19,7 @@ module Refinery
         options[:name] = name.to_s
         options[:page_id] ||= options[:page].try(:id)
 
-        phrase = self.find_by_name_and_page_id(options[:name], options[:page_id]) || self.create(options)
+        phrase = self.find_by_name_and_scope_and_page_id(options[:name], options[:scope], options[:page_id]) || self.create(options)
         phrase.update_attributes(options.except(:value, :page, :page_id, :locale))
         phrase.last_access_at = Date.today
         phrase.save if phrase.changed?

--- a/spec/models/copywriting_phrase_spec.rb
+++ b/spec/models/copywriting_phrase_spec.rb
@@ -22,7 +22,12 @@ describe Refinery::Copywriting::Phrase do
       Refinery::Copywriting::Phrase.where(:name => 'name').count.should == 1
     end
 
-    it "should return the string the value once its set" do
+    it "differentiates records by scope" do
+      2.times {|n| Refinery::Copywriting::Phrase.for('name', {:scope => "scope#{n}", :default => 'default'}) }
+      Refinery::Copywriting::Phrase.where(:name => 'name').pluck(:scope).should =~ ['scope0', 'scope1']
+    end
+
+    it "should return the string the value once it is set" do
       Refinery::Copywriting::Phrase.for('name', {:scope => 'scope', :default => 'default'}).should == 'default'
       copy = Refinery::Copywriting::Phrase.where(:name => 'name').first
       copy.value = 'updated!'


### PR DESCRIPTION
Frequently, when I'm creating a site, I'll have elements that have similar names, but are differentiated by their scope (i.e. I might have a 'read more' button that's applicable to both blog and news posts). At present, copywriting will only create one entry for each 'read_more' button, whereas I hold that it is useful and expected behaviour to create multiple entries. As an analogy, you should be able to have a file called 'my_text_file.txt' in both folders Foo and Bar.

This commit addresses that shortcoming and adds an appropriate test to ensure scoping is respected.
