### PR TITLE
fix asset pipeline precompilation errors in production

### DIFF
--- a/app/assets/stylesheets/refinery/copywriting/backend.css.scss
+++ b/app/assets/stylesheets/refinery/copywriting/backend.css.scss
@@ -1,3 +1,7 @@
+.scope_icon {
+  background-image: url("/assets/refinery/icons/zoom.png");
+}
+
 #copywriting-tab {
   ul {
     padding: 0 5px 10px 10px;

--- a/app/assets/stylesheets/refinerycms-copywriting.css.scss
+++ b/app/assets/stylesheets/refinerycms-copywriting.css.scss
@@ -1,3 +1,0 @@
-.scope_icon {
-  background-image: url("/assets/refinery/icons/zoom.png");
-}

--- a/app/views/refinery/copywriting/admin/phrases/index.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/index.html.erb
@@ -6,5 +6,5 @@
 </aside>
 
 <% content_for :stylesheets do %>
-  <%= stylesheet_link_tag 'refinerycms-copywriting' %>
+  <%= stylesheet_link_tag 'refinery/copywriting/backend' %>
 <% end %>

--- a/app/views/refinery/pages/admin/tabs/_copywriting.html.erb
+++ b/app/views/refinery/pages/admin/tabs/_copywriting.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <% content_for :stylesheets do %>
-  <%= stylesheet_link_tag 'refinerycms-copywriting-tab' %>
+  <%= stylesheet_link_tag 'refinery/copywriting/backend' %>
 <% end %>


### PR DESCRIPTION
specfically fixes the following two errors that were occuring in production:
refinerycms-copywriting.css isn't precompiled
refinerycms-copywriting-tab.css isn't precompiled
