### PR TITLE
Used the same phrase name value in the form as in the index

### DIFF
--- a/app/views/refinery/copywriting/admin/phrases/_value_field.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_value_field.html.erb
@@ -1,5 +1,5 @@
 <div class='field'>
-  <%= f.label :value, f.object.name.capitalize -%>
+  <%= f.label :value, f.object.name -%>
   <% value = f.object.default_or_value %>
   <% case f.object.phrase_type %>
   <% when "text" %>


### PR DESCRIPTION
https://github.com/unixcharles/refinerycms-copywriting/blob/master/app/views/refinery/copywriting/admin/phrases/_phrase.html.erb#L6 does not capitalize the phrase name. The problem with `capitalize` is that it will make any other words lowercase. For instance "My URL" becomes "My url".
