### PR TITLE
Reorder phrases

### DIFF
--- a/app/controllers/refinery/copywriting/admin/phrases_controller.rb
+++ b/app/controllers/refinery/copywriting/admin/phrases_controller.rb
@@ -5,7 +5,7 @@ module Refinery
         before_filter :find_all_locales, :find_locale, :find_scope, :find_all_scopes
 
         crudify :'refinery/copywriting/phrase', :searchable => false,
-                :title_attribute => 'name', :xhr_paging => true, :sortable => false,
+                :title_attribute => 'name', :xhr_paging => true, :sortable => true,
                 :redirect_to_url => 'refinery.copywriting_admin_phrases_path'
 
         protected
@@ -16,6 +16,9 @@ module Refinery
           if find_scope
             @phrases = @phrases.where(:scope => find_scope)
           end
+
+          @phrases_by_scope = @phrases.group_by(&:scope)
+
         end
 
         def find_locale

--- a/app/models/refinery/copywriting/phrase.rb
+++ b/app/models/refinery/copywriting/phrase.rb
@@ -6,7 +6,7 @@ module Refinery
       translates :value if self.respond_to?(:translates)
       validates :name, :presence => true
 
-      default_scope { order([:scope, :name]) }
+      default_scope { order([:scope, :position]) }
 
       def self.for(name, options = {})
         options = {:phrase_type => 'text', :scope => 'default'}.merge(options.reject {|k,v| v.blank? })

--- a/app/views/refinery/copywriting/admin/phrases/_actions.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_actions.html.erb
@@ -1,2 +1,3 @@
 <%= render 'locale_filters' if defined?(::Refinery::I18n) %>
 <%= render 'scope_filters' %>
+<%= render 'reorder' %>

--- a/app/views/refinery/copywriting/admin/phrases/_phrase.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_phrase.html.erb
@@ -1,8 +1,5 @@
 <li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(phrase) -%>">
   <span class='title'>
-    <% if @scope.nil? and phrase.scope %>
-      <%= link_to phrase.scope.capitalize, refinery.copywriting_admin_phrases_path(:filter_scope => phrase.scope) %>
-    <% end %>
     <b><%= phrase.name %></b>
     <span class="preview">- <%= truncate(phrase.default_or_value, :length => 40) %></span>
   </span>

--- a/app/views/refinery/copywriting/admin/phrases/_phrases.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_phrases.html.erb
@@ -1,4 +1,15 @@
-<%= will_paginate @phrases, :params => { :controller => "refinery/copywriting/admin/phrases", :action => "index" } %>
-<ul id='phrases'>
-  <%= render :partial => 'refinery/copywriting/admin/phrases/phrase', :collection => @phrases %>
-</ul>
+<%#= will_paginate @phrases, :params => { :controller => "refinery/copywriting/admin/phrases", :action => "index" } %>
+<% @phrases_by_scope.each do |scope_name, phrases| %>
+
+  <% if @scope %>
+    <h3><%= @scope.name %></h3>
+  <% else %>
+    <% if scope_name == "default" %>
+      <h3>Unscoped</h3>
+    <% else %>
+      <h3><%= link_to scope_name.capitalize, refinery.copywriting_admin_phrases_path(:filter_scope => scope_name) %></h3>
+    <% end %>
+  <% end %>
+
+  <%= render 'sortable_list', phrases: phrases %>
+<% end %>

--- a/app/views/refinery/copywriting/admin/phrases/_reorder.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_reorder.html.erb
@@ -1,0 +1,16 @@
+<ul>
+<% if ::Refinery::Copywriting::Admin::PhrasesController.sortable? && ::Refinery::Copywriting::Phrase.many? %>
+  <li>
+    <%= link_to t('.reorder', :what => "Phrases"),
+                 refinery.copywriting_admin_phrases_path,
+                 :id => "reorder_action",
+                 :class => "reorder_icon" %>
+
+    <%= link_to t('.reorder_done', :what => "Phrases"),
+                 refinery.copywriting_admin_phrases_path,
+                 :id => "reorder_action_done",
+                 :style => "display: none;",
+                 :class => "reorder_icon" %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/refinery/copywriting/admin/phrases/_sortable_list.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/_sortable_list.html.erb
@@ -1,0 +1,5 @@
+<ul id='phrases' class="sortable_list">
+  <%= render :partial => 'refinery/copywriting/admin/phrases/phrase', :collection => phrases %>
+</ul>
+<%= render '/refinery/admin/sortable_list',
+            :continue_reordering => (local_assigns.keys.include?(:continue_reordering)) ? continue_reordering : true %>

--- a/app/views/refinery/copywriting/admin/phrases/index.html.erb
+++ b/app/views/refinery/copywriting/admin/phrases/index.html.erb
@@ -5,6 +5,9 @@
   <%= render 'actions' %>
 </aside>
 
+
+<%= render '/refinery/admin/make_sortable', options: {tree: false} if ::Refinery::Copywriting::Admin::PhrasesController.sortable? and ::Refinery::Copywriting::Phrase.many? %>
+
 <% content_for :stylesheets do %>
   <%= stylesheet_link_tag 'refinery/copywriting/backend' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,12 @@ Refinery::Core::Engine.routes.draw do
   namespace :copywriting, :path => '' do
     namespace :admin, :path => 'refinery' do
       scope :path => 'copywriting' do
-        resources :phrases, :except => [:show, :new, :create]
+        resources :phrases, :except => [:show, :new, :create] do
+          collection do
+            post :update_positions
+          end
+        end
       end
     end
-  end
+  end  
 end

--- a/db/migrate/6_add_position_to_phrases.rb
+++ b/db/migrate/6_add_position_to_phrases.rb
@@ -1,0 +1,11 @@
+class AddPositionToPhrases < ActiveRecord::Migration
+
+  def self.up
+    add_column Refinery::Copywriting::Phrase.table_name, :position, :integer
+  end
+
+  def self.down
+    remove_column Refinery::Copywriting::Phrase.table_name, :position
+  end
+
+end


### PR DESCRIPTION
Sometime phrases have a logical order (for example, when they're lines of an address) which we'd like the user to see.

Phrases are grouped by scope, and reorderable within each scope. 

Some issues still to work out with the JS controls.
