### PR TITLE
Display scope in tab template

### DIFF
--- a/app/views/refinery/pages/admin/tabs/_copywriting.html.erb
+++ b/app/views/refinery/pages/admin/tabs/_copywriting.html.erb
@@ -2,8 +2,9 @@
 <% if copywriting_phrases and copywriting_phrases.any? %>
   <div class='wym_skin_refinery page_part' id='copywriting-tab'>
     <ul>
-      <% copywriting_phrases.each do |phrase| %>
+      <% copywriting_phrases.group_by(&:scope).each do |scope, phrase| %>
         <li>
+          <h2><%= scope.humanize %></h2>
           <%= f.fields_for :copywriting_phrases, phrase do |p| %>
             <%= render 'refinery/copywriting/admin/phrases/value_field', :f => p %>
           <% end %>


### PR DESCRIPTION
It add the scope name in the page tab of copywriting :

```ruby
<%= copywriting_options({ scope: 'square_1', page: @page }) do %>
  <%=  copywriting('title', { phrase_type: 'string' }) %>
  <%=  copywriting('body', { phrase_type: 'wysiwyg' }) %>
<% end %>
``` 

![copywriting-add-scope](https://cloud.githubusercontent.com/assets/1678530/8881497/53a5e46e-320e-11e5-9650-daf5d994e95f.png)
